### PR TITLE
Only allow internal addresses to update FS and RTP caches

### DIFF
--- a/lib/options.js
+++ b/lib/options.js
@@ -1,7 +1,12 @@
+const CIDRMatcher = require('cidr-matcher');
 const debug = require('debug')('jambonz:sbc-options-handler');
 const fsServers = new Map();
 const fsServiceUrls = new Map();
 const rtpServers = new Map();
+
+const internalNetwork = new CIDRMatcher(
+  [(process.env.JAMBONES_NETWORK_CIDR ?? ['10.0.0.0/8', '172.16.0.0/12', '192.168.0.0/16'])].flat()
+);
 
 module.exports = ({srf, logger}) => {
   const {stats, addToSet, removeFromSet, isMemberOfSet, retrieveSet} = srf.locals;
@@ -104,13 +109,16 @@ module.exports = ({srf, logger}) => {
   };
 
   return async(req, res) => {
+    const {srf, source_address, locals: {logger}} = req;
 
     /* OPTIONS ping from internal FS or RTP server? */
-    const internal = req.has('X-FS-Status') || req.has('X-RTP-Status');
-    if (!internal) {
+    if (!internalNetwork.contains(source_address)) {
+      if (req.has('X-FS-Status') || req.has('X-RTP-Status')) {
+        logger.info('Received external OPTIONS with internal header(s)');
+      }
       debug('got external OPTIONS ping');
       res.send(200);
-      return req.srf.endSession(req);
+      return srf.endSession(req);
     }
 
     try {
@@ -118,7 +126,7 @@ module.exports = ({srf, logger}) => {
       const h = ['X-FS-Status', 'X-RTP-Status'].find((h) => req.has(h));
       if (h) {
         const isRtpServer = req.has('X-RTP-Status');
-        const key       = isRtpServer ? req.source_address : `${req.source_address}:${req.source_port}`;
+        const key       = isRtpServer ? source_address : `${source_address}:${req.source_port}`;
         const prefix    = isRtpServer ? 'X-RTP' : 'X-FS';
         map             = isRtpServer ? rtpServers : fsServers;
         const setName   = isRtpServer ? setNameRtp : setNameFs;
@@ -141,6 +149,6 @@ module.exports = ({srf, logger}) => {
       debug(err);
       logger.error({err}, 'Error handling OPTIONS');
     }
-    return req.srf.endSession(req);
+    return srf.endSession(req);
   };
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@jambonz/realtimedb-helpers": "^0.8.7",
         "@jambonz/stats-collector": "^0.1.9",
         "@jambonz/time-series": "^0.2.5",
+        "cidr-matcher": "^2.1.1",
         "debug": "^4.3.4",
         "drachtio-mw-registration-parser": "^0.1.0",
         "drachtio-mw-response-time": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -28,11 +28,12 @@
   "homepage": "https://github.com/jambonz/sbc-sip-sidecar#readme",
   "dependencies": {
     "@jambonz/db-helpers": "^0.9.1",
+    "@jambonz/digest-utils": "^0.0.3",
     "@jambonz/mw-registrar": "^0.2.4",
     "@jambonz/realtimedb-helpers": "^0.8.7",
     "@jambonz/stats-collector": "^0.1.9",
     "@jambonz/time-series": "^0.2.5",
-    "@jambonz/digest-utils": "^0.0.3",
+    "cidr-matcher": "^2.1.1",
     "debug": "^4.3.4",
     "drachtio-mw-registration-parser": "^0.1.0",
     "drachtio-mw-response-time": "^1.0.2",


### PR DESCRIPTION
I've updated the `internal` check in the `OPTIONS` handler so it doesn't rely on the presence of the `X-RTP-Status` or `X-FS-Status` header, instead it checks the source address against the internal network CIDR.