### PR TITLE
prevent crash when no Contact header in 200 OK response to REGISTER

### DIFF
--- a/lib/sip-trunk-register.js
+++ b/lib/sip-trunk-register.js
@@ -127,9 +127,9 @@ class Regbot {
             }
           } else {
             this.logger.info({ aor: this.aor, ipv4: this.ipv4, port: this.port },
-              `no Contact header in 200 OK`);
+              'no Contact header in 200 OK');
           }
-        
+
           if (isNaN(expires) || expires < MIN_EXPIRES) {
             this.logger.info({ aor: this.aor, ipv4: this.ipv4, port: this.port },
               `got expires of ${expires} in 200 OK, too small so setting to ${MIN_EXPIRES}`);

--- a/lib/sip-trunk-register.js
+++ b/lib/sip-trunk-register.js
@@ -109,17 +109,29 @@ class Regbot {
           this.timer = setTimeout(this.register.bind(this, srf), 30 * 1000);
         }
         else {
+
+          // the code parses the SIP headers to get the expires value
+          // if there is a Contact header, it will use the expires value from there
+          // otherwise, it will use the Expires header, acording to the SIP RFC 3261, section 10.2.4 Refreshing Bindings
           this.status = 'registered';
           let expires = DEFAULT_EXPIRES;
-          const contact = res.getParsedHeader('Contact');
-          if (contact.length > 0 && contact[0].params && contact[0].params.expires) {
-            if (contact[0].params.expires) expires = parseInt(contact[0].params.expires);
-          }
-          else if (res.has('Expires')) {
+
+          if (res.has('Expires')) {
             expires = parseInt(res.get('Expires'));
           }
+
+          if (res.has('Contact')) {
+            const contact = res.getParsedHeader('Contact');
+            if (contact.length > 0 && contact[0].params && contact[0].params.expires) {
+              expires = parseInt(contact[0].params.expires);
+            }
+          } else {
+            this.logger.info({ aor: this.aor, ipv4: this.ipv4, port: this.port },
+              `no Contact header in 200 OK`);
+          }
+        
           if (isNaN(expires) || expires < MIN_EXPIRES) {
-            this.logger.info({aor: this.aor, ipv4: this.ipv4, port: this.port},
+            this.logger.info({ aor: this.aor, ipv4: this.ipv4, port: this.port },
               `got expires of ${expires} in 200 OK, too small so setting to ${MIN_EXPIRES}`);
             expires = MIN_EXPIRES;
           }


### PR DESCRIPTION
This PR prevents a crash, which can happen when a REGISTER request is made.
When the "200 OK" response is malformed and doesn't include a Contact header, an unhandled exception occurs and the application crashes.

To prevent that, a `if (res.has('Contact'))` was added.

Also the processing was adapted a bit for better readability.