### PR TITLE
Change timer for next REGISTER expires / 2 to avoid delayed registrations

### DIFF
--- a/lib/sip-trunk-register.js
+++ b/lib/sip-trunk-register.js
@@ -177,7 +177,7 @@ class Regbot {
             expires = MIN_EXPIRES;
           }
           debug(`setting timer for next register to ${expires} seconds`);
-          this.timer = setTimeout(this.register.bind(this, srf), (expires - 5) * 1000);
+          this.timer = setTimeout(this.register.bind(this, srf), (expires / 2) * 1000);
         }
         updateVoipCarriersRegisterStatus(this.voip_carrier_sid, JSON.stringify({
           status: res.status === 200 ? 'ok' : 'fail',


### PR DESCRIPTION
We were facing an issue that due to the implementation of `expires - 5 ` an expire of 900s (15mins) was delayed when the system was under high volume.

Therefore this PR changes the timer for the next registration to `expires / 2` to always be in time.