### PR TITLE
add expires and timestamp to database status

### DIFF
--- a/lib/regbot.js
+++ b/lib/regbot.js
@@ -5,7 +5,6 @@ const {
   REGISTER_RESPONSE_REMOVE,
   JAMBONES_REGBOT_USER_AGENT
 } = require('./config');
-const debug = require('debug')('jambonz:sbc-registrar');
 const {isValidDomainOrIP} = require('./utils');
 const DEFAULT_EXPIRES = (parseInt(JAMBONES_REGBOT_DEFAULT_EXPIRES_INTERVAL) || 3600);
 const MIN_EXPIRES = (parseInt(JAMBONES_REGBOT_MIN_EXPIRES_INTERVAL) || 30);
@@ -131,6 +130,7 @@ class Regbot {
         }
       });
       req.on('response', async(res) => {
+        let expires;
         if (res.status !== 200) {
           this.status = 'fail';
           this.logger.info(`${this.aor}: got ${res.status} registering to ${this.ipv4}:${this.port}`);
@@ -150,17 +150,18 @@ class Regbot {
               });
             }
           }
+          expires = 0;
         }
         else {
-
           // the code parses the SIP headers to get the expires value
           // if there is a Contact header, it will use the expires value from there
           // otherwise, it will use the Expires header, acording to the SIP RFC 3261, section 10.2.4 Refreshing Bindings
           this.status = 'registered';
-          let expires = DEFAULT_EXPIRES;
+          expires = DEFAULT_EXPIRES;
 
           if (res.has('Expires')) {
-            expires = parseInt(res.get('Expires'));
+            expires = await parseInt(res.get('Expires'));
+            this.logger.debug(`Using Expires header value of ${expires}`);
           }
 
           if (res.has('Contact')) {
@@ -169,23 +170,26 @@ class Regbot {
               expires = parseInt(contact[0].params.expires);
             }
           } else {
-            this.logger.info({ aor: this.aor, ipv4: this.ipv4, port: this.port },
+            this.logger.debug({ aor: this.aor, ipv4: this.ipv4, port: this.port },
               'no Contact header in 200 OK');
           }
 
           if (isNaN(expires) || expires < MIN_EXPIRES) {
-            this.logger.info({ aor: this.aor, ipv4: this.ipv4, port: this.port },
+            this.logger.debug({ aor: this.aor, ipv4: this.ipv4, port: this.port },
               `got expires of ${expires} in 200 OK, too small so setting to ${MIN_EXPIRES}`);
             expires = MIN_EXPIRES;
           }
-          debug(`setting timer for next register to ${expires} seconds`);
+          this.logger.debug(`setting timer for next register to ${expires} seconds`);
           this.timer = setTimeout(this.register.bind(this, srf), (expires / 2) * 1000);
         }
+        const timestamp = new Date().toISOString();
         updateVoipCarriersRegisterStatus(this.voip_carrier_sid, JSON.stringify({
           status: res.status === 200 ? 'ok' : 'fail',
           reason: `${res.status} ${res.reason}`,
           cseq: req.get('Cseq'),
-          callId: req.get('Call-Id')
+          callId: req.get('Call-Id'),
+          timestamp: timestamp,
+          expires: expires
         }));
       });
     } catch (err) {
@@ -201,3 +205,4 @@ class Regbot {
 }
 
 module.exports = Regbot;
+


### PR DESCRIPTION
also cleaned up and added some logging so debug gives a consistent view of the registration flow

fixes. #81

expires value and timestamp are now returned in the api call to get a carrier 
<img width="452" height="267" alt="image" src="https://github.com/user-attachments/assets/0292c61e-3d1f-4667-b726-b9de5b8bdd8c" />
