### PR TITLE
Fix/regtrunks

### DIFF
--- a/lib/regbot.js
+++ b/lib/regbot.js
@@ -204,14 +204,14 @@ class Regbot {
         }));
 
         // for reg trunks, create ephemeral set of IP addresses for inbound gateways
-        if (this.trunk_type === 'reg') {
+        if (this.trunk_type === 'reg' && !isValidIPv4(this.ipv4)) {
           this.addresses = [];
           if (this.port) {
-            const addrs = await dnsResolverA(this.logger, this.sip_realm);
+            const addrs = await dnsResolverA(this.logger, this.ipv4);
             this.addresses.push(...addrs);
           }
           else {
-            const addrs = await dnsResolverSrv(this.logger, this.sip_realm, this.transport);
+            const addrs = await dnsResolverSrv(this.logger, this.ipv4, this.transport);
             this.addresses.push(...addrs);
           }
 


### PR DESCRIPTION
Changes to regtrunk to use the gateway hostname instead of the realm.
Also fixes an issue previously introduced where regbot would fail if the port was null instead of using SRV lookup