### PR TITLE
fixed Array.prototype.push.apply will throw Maximum call stack size exceeded

### DIFF
--- a/lib/sip-trunk-register.js
+++ b/lib/sip-trunk-register.js
@@ -224,13 +224,16 @@ const updateCarrierRegbots = async(logger, srf) => {
       debug('updateCarrierRegbots: got new or changed carriers');
       logger.info({gws}, 'updateCarrierRegbots: got new or changed carriers');
 
-      // Clear and repopulate arrays safely to avoid argument limit
-      // Array.prototype.push.apply will throw Maximum call stack size exceeded
+      // Clear and repopulate arrays in chunks to avoid argument limit
       carriers.length = 0;
-      for (const c of cs) carriers.push(c);
+      for (let i = 0; i < cs.length; i += 1000) {
+        Array.prototype.push.apply(carriers, cs.slice(i, i + 1000));
+      }
 
       gateways.length = 0;
-      for (const gw of gws) gateways.push(gw);
+      for (let i = 0; i < gws.length; i += 1000) {
+        Array.prototype.push.apply(gateways, gws.slice(i, i + 1000));
+      }
 
       // stop / kill existing regbots
       regbots.forEach((rb) => rb.stop(srf));

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "tape": "^5.7.5"
       },
       "engines": {
-        "node": ">= 18.0.0"
+        "node": ">= 20.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {


### PR DESCRIPTION
when we have large number of voip carriers that need to do register, the app crash due to Maximum call stack size