### PR TITLE
chore: bump drachtio-srf to ^5.0.25

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "debug": "^4.4.3",
         "drachtio-mw-registration-parser": "^0.1.2",
         "drachtio-mw-response-time": "^1.0.2",
-        "drachtio-srf": "^5.0.21",
+        "drachtio-srf": "^5.0.25",
         "pino": "^10.1.0",
         "short-uuid": "^4.2.2"
       },
@@ -1409,9 +1409,9 @@
       "integrity": "sha512-d+DtKuqhpkSBBkRfwcgS3x26T3lrdgo86yVWZ4wy+K8RtS1faT3hgLBq9EPEYSDkcw76r4klvdDWPhTrPqGAQw=="
     },
     "node_modules/drachtio-srf": {
-      "version": "5.0.21",
-      "resolved": "https://registry.npmjs.org/drachtio-srf/-/drachtio-srf-5.0.21.tgz",
-      "integrity": "sha512-9hkQ7LURI1ceTMs49Nh2aosAd2v0565eD8Ccho5sSzXEHuq0DE3epjStlThq6LvIGVVAOXuSQGXFmlMWK92R3w==",
+      "version": "5.0.25",
+      "resolved": "https://registry.npmjs.org/drachtio-srf/-/drachtio-srf-5.0.25.tgz",
+      "integrity": "sha512-8AGJdRx4zKCrwQJbNL8e2OjdGsAZqdUgrnRnUftiv72AphrROj1pXr2Utt4rj7ccDp17VlbzE3qJXvQF8OoX6w==",
       "license": "MIT",
       "dependencies": {
         "debug": "^4.4.3",
@@ -1419,7 +1419,7 @@
         "node-noop": "^1.0.0",
         "only": "^0.0.2",
         "sdp-transform": "^2.15.0",
-        "short-uuid": "^5.2.0",
+        "short-uuid": "^6.0.3",
         "sip-methods": "^0.3.0",
         "sip-status": "^0.1.0",
         "utils-merge": "^1.0.1",
@@ -1430,29 +1430,15 @@
       }
     },
     "node_modules/drachtio-srf/node_modules/short-uuid": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/short-uuid/-/short-uuid-5.2.0.tgz",
-      "integrity": "sha512-296/Nzi4DmANh93iYBwT4NoYRJuHnKEzefrkSagQbTH/A6NTaB68hSPDjm5IlbI5dx9FXdmtqPcj6N5H+CPm6w==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/short-uuid/-/short-uuid-6.0.3.tgz",
+      "integrity": "sha512-UMZ3rYOoid307EqWsPTnoBUSOB51Fi28vUMPigUsSCmbaSvslyf/SlXZWOn4btj8tokhBTBkPFKVKKlIolEG1w==",
       "license": "MIT",
       "dependencies": {
-        "any-base": "^1.1.0",
-        "uuid": "^9.0.1"
+        "any-base": "^1.1.0"
       },
       "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/drachtio-srf/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
+        "node": ">=14.17.0"
       }
     },
     "node_modules/dunder-proto": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "debug": "^4.4.3",
     "drachtio-mw-registration-parser": "^0.1.2",
     "drachtio-mw-response-time": "^1.0.2",
-    "drachtio-srf": "^5.0.21",
+    "drachtio-srf": "^5.0.25",
     "pino": "^10.1.0",
     "short-uuid": "^4.2.2"
   },


### PR DESCRIPTION
Updates drachtio-srf to the latest release (5.0.25), previously ^5.0.21.

Updated `package.json` and `package-lock.json` together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)